### PR TITLE
6.8 引数への代入の除去 (Remove Assignments to Parameters)

### DIFF
--- a/lib/6.8-remove_assignments_to_parameters.rb
+++ b/lib/6.8-remove_assignments_to_parameters.rb
@@ -1,8 +1,9 @@
 class RemoveAssignmentsToParameters
   def discount(input_val, quantity, year_to_date)
-    input_val -= 2 if input_val > 50
-    input_val -= 1 if quantity > 100
-    input_val -= 4 if year_to_date > 10000
-    input_val
+    result = input_val
+    result -= 2 if input_val > 50
+    result -= 1 if quantity > 100
+    result -= 4 if year_to_date > 10000
+    result
   end
 end

--- a/lib/6.8-remove_assignments_to_parameters.rb
+++ b/lib/6.8-remove_assignments_to_parameters.rb
@@ -1,0 +1,8 @@
+class RemoveAssignmentsToParameters
+  def discount(input_val, quantity, year_to_date)
+    input_val -= 2 if input_val > 50
+    input_val -= 1 if quantity > 100
+    input_val -= 4 if year_to_date > 10000
+    input_val
+  end
+end

--- a/spec/6.8-remove_assignments_to_parameters_spec.rb
+++ b/spec/6.8-remove_assignments_to_parameters_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe RemoveAssignmentsToParameters do
+  describe '#discount' do
+    instance = RemoveAssignmentsToParameters.new
+
+    context 'input_val > 50, quantity > 100, year_to_date > 10000' do
+      it 'returns 93' do
+        expect(instance.discount(100, 200, 20000)).to eq 93
+      end
+    end
+
+    context 'input_val > 50, quantity > 100, year_to_date <= 10000' do
+      it 'returns 97' do
+        expect(instance.discount(100, 200, 10000)).to eq 97
+      end
+    end
+
+    context 'input_val > 50, quantity <= 100, year_to_date > 10000' do
+      it 'returns 94' do
+        expect(instance.discount(100, 100, 20000)).to eq 94
+      end
+    end
+
+    context 'input_val > 50, quantity <= 100, year_to_date <= 10000' do
+      it 'returns 98' do
+        expect(instance.discount(100, 100, 10000)).to eq 98
+      end
+    end
+
+    context 'input_val <= 50, quantity > 100, year_to_date > 10000' do
+      it 'returns 95' do
+        expect(instance.discount(50, 200, 20000)).to eq 45
+      end
+    end
+
+    context 'input_val > 50, quantity <= 100, year_to_date <= 10000' do
+      it 'returns 98' do
+        expect(instance.discount(100, 100, 10000)).to eq 98
+      end
+    end
+  end
+end


### PR DESCRIPTION
引数に代入を行っている箇所を除去し、代わりに一時変数を使う。(149〜153p)